### PR TITLE
fix: change min height for textual v0.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.2]
+
+### Fixed
+
+- Fix the slider not showing in Textual v0.42.0 due to `min-height` change https://github.com/TomJGooding/textual-slider/issues/39
+
+### Changed
+
+- Bump the minimum Textual version to 0.42.0
 
 ## [0.1.1] - 2023-07-05
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    textual >= 0.24.0
+    textual >= 0.42.0
 
 [options.packages.find]
 where = src
@@ -33,4 +33,4 @@ dev =
     mypy
     pytest
     pytest-cov
-    textual[dev]
+    textual-dev

--- a/src/textual_slider/__init__.py
+++ b/src/textual_slider/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from textual_slider._slider import Slider
 

--- a/src/textual_slider/_slider.py
+++ b/src/textual_slider/_slider.py
@@ -26,8 +26,8 @@ class Slider(Widget, can_focus=True):
     DEFAULT_CSS = """
     Slider {
         width: 32;
-        height: 1;
-        min-height: 1;
+        height: 3;
+        min-height: 3;
         border: tall transparent;
         background: $boost;
         padding: 0 2;


### PR DESCRIPTION
### Description

Fix the slider not showing in Textual v0.42.0 due to `min-height` change, where "the max/min-width/height now includes padding and border".

### Related Issue

- #39

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
