### PR TITLE
feat!: require optional arguments to be keyword-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- BREAKING CHANGE: The `Slider` constructor now requires optional parameters to be specified as keyword-only arguments.
+
 ## [0.1.2] - 2023-11-27
 
 ### Fixed

--- a/src/textual_slider/_slider.py
+++ b/src/textual_slider/_slider.py
@@ -69,6 +69,7 @@ class Slider(Widget, can_focus=True):
         self,
         min: int,
         max: int,
+        *,
         step: int = 1,
         value: int | None = None,
         name: str | None = None,


### PR DESCRIPTION
BREAKING CHANGE: The Slider constructor now requires optional parameters to be specified as keyword-only arguments.