### PR TITLE
feat: enable clicking to quickly move the slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Enable clicking to quickly move the slider rather than dragging https://github.com/TomJGooding/textual-slider/pull/46
+
 ### Changed
 
-- BREAKING CHANGE: The `Slider` constructor now requires optional parameters to be specified as keyword-only arguments.
+- BREAKING CHANGE: The `Slider` constructor now requires optional parameters to be specified as keyword-only arguments https://github.com/TomJGooding/textual-slider/pull/44
 
 ## [0.1.2] - 2023-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Enable clicking to quickly move the slider rather than dragging https://github.com/TomJGooding/textual-slider/pull/46
+- Enable clicking (mouse down) to quickly move the slider rather than dragging https://github.com/TomJGooding/textual-slider/pull/46
 
 ### Changed
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths =
+    tests
+asyncio_mode = auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,5 +32,6 @@ dev =
     isort
     mypy
     pytest
+    pytest-asyncio
     pytest-cov
     textual-dev

--- a/tests/test_slider.py
+++ b/tests/test_slider.py
@@ -1,0 +1,40 @@
+from textual.app import App, ComposeResult
+
+from textual_slider import Slider
+
+
+class SliderApp(App):
+    CSS = """
+    Screen {
+        align: center middle;
+    }
+
+    Slider {
+        width: 18;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Slider(0, 9, step=3)
+
+
+async def test_clicking_slider_updates_position_and_value() -> None:
+    app = SliderApp()
+    async with app.run_test() as pilot:
+        slider = pilot.app.query_one(Slider)
+
+        await pilot.click(Slider, offset=(13, 1))
+        assert slider.value == 9
+        assert slider._slider_position == 75.0
+
+        await pilot.click(Slider, offset=(10, 1))
+        assert slider.value == 6
+        assert slider._slider_position == 50.0
+
+        await pilot.click(Slider, offset=(7, 1))
+        assert slider.value == 3
+        assert slider._slider_position == 25.0
+
+        await pilot.click(Slider, offset=(4, 1))
+        assert slider.value == 0
+        assert slider._slider_position == 0.0


### PR DESCRIPTION
Closes #43.

Enable clicking (mouse down) to quickly move the slider rather than dragging. If the mouse button is held down, the slider can then be dragged for finer adjustments.