### PR TITLE
feat: change mouse pointer when slider grabbed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+= Change mouse pointer when slider grabbed (in supported terminals) https://github.com/TomJGooding/textual-slider/pull/56
+
 ### Changed
 
 - Bump the minimum Textual version to 7.4.0 https://github.com/TomJGooding/textual-slider/pull/55

--- a/src/textual_slider/_slider.py
+++ b/src/textual_slider/_slider.py
@@ -44,6 +44,8 @@ class Slider(Widget, can_focus=True):
     }
     """
 
+    ALLOW_SELECT = False
+
     value: reactive[int] = reactive(0, init=False)
     """The value of the slider."""
 
@@ -181,10 +183,12 @@ class Slider(Widget, can_focus=True):
         event.stop()
 
     def _on_mouse_capture(self, event: events.MouseCapture) -> None:
+        self.styles.pointer = "grabbing"
         self._grabbed = event.mouse_position
         self._grabbed_position = self._slider_position
 
     def _on_mouse_release(self, event: events.MouseRelease) -> None:
+        self.styles.pointer = "default"
         self._grabbed = None
         event.stop()
 


### PR DESCRIPTION
Textual v7.4.0 added the ability to change the mouse pointer shape in terminals that support the protocol.

Change the pointer to the closed hand (grabbing) shape when the slider is grabbed.